### PR TITLE
[hotfix] typing backwards compatibility

### DIFF
--- a/pinn/cli.py
+++ b/pinn/cli.py
@@ -8,6 +8,7 @@ import random
 import subprocess
 import click, pinn, os
 from pinn.report import report_log
+from typing import List
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 CONTEXT_SETTINGS = dict()
@@ -185,7 +186,7 @@ def log(logdir, tag, fmt):
 @click.argument('model_host_path', metavar='model_host_path', nargs=1)
 @click.option('-f', '--filter', metavar='', default='', show_default=True)
 @click.option('-l', '--log-name', metavar='', default='eval.log', show_default=True)
-def report(model_host_path:str, filter:list[str], log_name:str='eval.log'):
+def report(model_host_path:str, filter:List[str], log_name:str='eval.log'):
     model_host_path = Path(model_host_path)
     log_paths = model_host_path.glob(f'**/{log_name}')
     report_log(list(map(str, map(lambda x:x.parent, log_paths))), filter, log_name)

--- a/pinn/report.py
+++ b/pinn/report.py
@@ -3,26 +3,27 @@
 """
 Script to generate reports from benchmar results
 """
-from collections import defaultdict
 import re, os
 import warnings
 import numpy as np
+from typing import List
 from glob import glob
 from pathlib import Path
+from collections import defaultdict
 
 hartree2meV = 27.2114079527 * 1000
 kcalpermol2meV = 0.0433641153087705 * 1000
 
-def report_log(model_paths:list[str], keyword_filter:list[str]=[], log_name:str = 'eval.log'):
+def report_log(model_paths:List[str], keyword_filter:List[str]=[], log_name:str = 'eval.log'):
     """
     report log of training process
 
     Args:
-        model_paths (list[str]): path the model host, e.g. models/pinet2-pot-simple-nofrc-qm9-bs120-1. The identifier of this model is [pinet2, pot, simple, nofrc, qm9, bs120], but exclude the last number.
+        model_paths (List[str]): path the model host, e.g. models/pinet2-pot-simple-nofrc-qm9-bs120-1. The identifier of this model is [pinet2, pot, simple, nofrc, qm9, bs120], but exclude the last number.
 
         log_name (str, optional): name of log file. Defaults to 'eval.log'.
 
-        keyword_filter (list[str], optional): filter option, only report the model contains all the args. Defaults to [].
+        keyword_filter (List[str], optional): filter option, only report the model contains all the args. Defaults to [].
     """
     # groupby name of model
     trials = defaultdict(list) # {name: [path1, path2, ...]}


### PR DESCRIPTION
change `list[str]` to `List[str]` in order to compatible with python 3.6