### PR TITLE
[ut] reduce training step in test_dipole to reduce rtol

### DIFF
--- a/tests/test_dipole.py
+++ b/tests/test_dipole.py
@@ -275,7 +275,7 @@ def _dipole_tests(params):
         500).apply(sparse_batch(50))
 
     def test(): return load_numpy(data).apply(sparse_batch(10))
-    train_spec = tf.estimator.TrainSpec(input_fn=train, max_steps=1e3)
+    train_spec = tf.estimator.TrainSpec(input_fn=train, max_steps=1e2)
     eval_spec = tf.estimator.EvalSpec(input_fn=test, steps=100)
 
     model = pinn.get_model(params)


### PR DESCRIPTION
It only affects the test pass rate. 

```
"test_dipole.py failed randomly, since the relative error somehow is too big":

Yes, but look at how that is calculated. 
This is the difference between D_RMSE and calculating it manually. 
That has to be because the numbers are so small.
Otherwise, it cannot be wrong.
The model has a report D_RMSE of 6E-8.

You need a big relative error and a small absolute error.
are you sure you want to loose more rtol to fit the result?

No, I think if we train for very little steps it should be better.
The prediction error should be larger avoiding this problem.
```