### PR TITLE
Fix build error: "Error: Cache service responded with 400"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.py-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py-version }}
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to Docker Hub
@@ -57,12 +57,12 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_REPO }}:${{ env.TAG }}-cpu
   build-cpu-to-now-org:
-    name: Build docker (cpu)
+    name: Build docker (cpu) - new
     needs: pytest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to Docker Hub
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to Docker Hub
@@ -96,12 +96,12 @@ jobs:
           file: Dockerfile.gpu
           tags: ${{ secrets.DOCKERHUB_REPO }}:${{ env.TAG }}-gpu
   build-gpu-to-now-org:
-    name: Build docker (gpu)
+    name: Build docker (gpu) - new
     needs: pytest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to Docker Hub
@@ -121,11 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # see https://github.com/jimporter/mike/issues/28
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
           cache: "pip"

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         py-version: ["3.8", "3.9", "3.10"]
-        experimental: [false]
     steps:
       - name: Checkout master
         uses: actions/checkout@v5

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -14,11 +14,11 @@ jobs:
         experimental: [false]
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # see https://github.com/jimporter/mike/issues/28
       - name: Set up Python ${{ matrix.py-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py-version }}
           cache: "pip"

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         py-version: ["3.8", "3.9", "3.10"]
     steps:

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,6 +4,6 @@ mkdocs-flux==0.0.6
 pygments==2.16.1
 pymdown-extensions==10.2.1
 mkdocs-bibtex==2.11.0
-mkdocstrings[python]==0.26.0
+mkdocstrings[python]==0.30.1
 pypandoc_binary==1.12
 mknotebooks==0.8.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,6 +4,6 @@ mkdocs-flux==0.0.6
 pygments==2.16.1
 pymdown-extensions==10.2.1
 mkdocs-bibtex==2.11.0
-mkdocstrings[python]==0.30.1
+mkdocstrings[python]==0.26.1
 pypandoc_binary==1.12
 mknotebooks==0.8.0


### PR DESCRIPTION
```
Run actions/setup-python@v3
Successfully setup CPython (3.9.23)
/opt/hostedtoolcache/Python/3.9.23/x64/bin/pip cache dir
/home/runner/.cache/pip
Error: Cache service responded with 400
```

The HTTP 400 Bad Request client error response status code indicates that the server would not process the request due to something the server considered to be a client error. Since we didn't change the code I assume it's because some internal issues.

Checking `setup-python`, they are using `checkout@5` and `setup-python@6`. I also assume it's because old API serivce raises the error, and it looks like backward compatible. So I updated it and it works well on `test doc building` action.

I also updated mkdocstrings since 0.26.0 has a weired error: `AttributeError: 'dict' object has no attribute 'link_titles'`, see: https://github.com/mkdocstrings/autorefs/issues/68

PS: I also assume we just need to rerun it without caching, but i can't find option. So let's just update actions. I don't see any harm.