### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.py-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.py-version }}
           cache: "pip"
           cache-dependency-path: "requirements*.txt"
       - name: Cache regression test files
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pinn/regression
           key: ${{ hashFiles('tests/test_regression.py') }}
@@ -56,18 +56,21 @@ jobs:
       PUSH_IMAGE: ${{ github.repository == 'Teoroo-CMC/PiNN' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
         if: env.PUSH_IMAGE == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
+          context: .
           push: ${{ env.PUSH_IMAGE == 'true' }}
           tags: ${{ env.PUSH_IMAGE == 'true' && format('{0}:{1}-cpu', secrets.DOCKERHUB_REPO, env.TAG) || format('pinn:{0}-cpu', env.TAG) }}
   build-cpu-to-new-org:
@@ -77,17 +80,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Get Tag
         run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.NEW_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEW_DOCKERHUB_PASSWORD }}
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
+          context: .
           push: true
           tags: ${{ vars.NEW_DOCKERHUB_REPO }}:${{ env.TAG }}-cpu
   deploy-docs:
@@ -97,11 +103,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # see https://github.com/jimporter/mike/issues/28
       - name: Set up Python 3.9
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: 3.9
           cache: "pip"

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -18,11 +18,11 @@ jobs:
         py-version: ["3.9", "3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # see https://github.com/jimporter/mike/issues/28
       - name: Set up Python ${{ matrix.py-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.py-version }}
           cache: "pip"


### PR DESCRIPTION
## Summary
- Move workflow actions off Node 16/20 onto Node 24, matching [GitHub's runner deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
- `actions/cache@v3` was the source of the Node 20 warning on `master` / `v2.1.0` CI; Docker login/build-push were still on v1/v2 (Node 20 or older).
- Docker jobs now build from `context: .` (the checkout) instead of the default git URL, so they no longer fail with `refs/pull/N/merge` after a PR is merged.

## Action bumps
| Action | From | To (Node 24) |
|---|---|---|
| `actions/checkout` | v5 | v7 |
| `actions/setup-python` | v6 | v7 |
| `actions/cache` | v3 (Node 16) | v5 |
| `docker/login-action` | v1 / v3 | v4 |
| `docker/build-push-action` | v2 | v7 |
| `docker/setup-buildx-action` | — | v4 |

## Test plan
- [ ] PR CI: pytest 3.9/3.10/3.11
- [ ] PR CI: docs build
- [ ] PR CI: CPU docker *build* (no push) succeeds using local context