### PR TITLE
Bump requests from 2.28.2 to 2.32.5

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - requests=2.28.2
+  - requests=2.32.5
   - pytest=8.1.1
   - pytest-cov=4.0.0
   - pip:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-requests==2.28.2
+requests==2.32.5
 pytest==8.1.1
 pytest-forked==1.6.0
 pytest-cov==4.0.0


### PR DESCRIPTION
## Summary
- Replace the stale Dependabot bump (#31, 2.28.2 → 2.32.2) with **2.32.5**, the newest `requests` that still supports Python 3.9.
- Same pin in `requirements-dev.txt` and `environment-dev.yml`.
- Closes the session `verify=False`, Proxy-Authorization leak, and `.netrc` credential-leak advisories. `extract_zipped_paths` (GHSA-gc5v-m9x4-r6x2) needs 2.33+, which dropped 3.9; PiNN does not use that API.

## Test plan
- [ ] pytest 3.9/3.10/3.11 (regression tests download via `requests.get`)