### PR TITLE
settings.dtype and MACE-style calculator default_dtype

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,10 +16,10 @@ documented in this change log.
 ### v2.1.1
 
 - Training:
-    * YAML `settings.train_dtype` (`float32` / `float64`, default
+    * YAML `settings.dtype` (`float32` / `float64`, default
       **float32**) sets the training float type. The ASE calculator takes
-      MACE-style `default_dtype` as a constructor argument only; empty
-      follows `train_dtype`.
+      MACE-style `default_dtype` as a constructor argument only; ``None``
+      follows `settings.dtype`.
 
 ### v2.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,9 +16,9 @@ documented in this change log.
 ### v2.1.1
 
 - Training:
-    * Optional YAML `precision` (`fp32` / `fp16` / `bf16`). Default remains
-      **fp32**. `fp16`/`bf16` use Keras mixed precision (float32 variables,
-      reduced-precision compute).
+    * Optional YAML `numeric.precision` (`fp32` / `fp16` / `bf16`). Default
+      remains **fp32**. `fp16`/`bf16` use Keras mixed precision (float32
+      variables, reduced-precision compute).
 
 ### v2.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,13 @@ documented in this change log.
 
 ## v2.x.y
 
+### v2.1.1
+
+- Training:
+    * Optional YAML `precision` (`fp32` / `fp16` / `bf16`). Default remains
+      **fp32**. `fp16`/`bf16` use Keras mixed precision (float32 variables,
+      reduced-precision compute).
+
 ### v2.1.0
 
 - Backend:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,9 +16,10 @@ documented in this change log.
 ### v2.1.1
 
 - Training:
-    * Optional YAML `numeric.precision` (`fp32` / `fp16` / `bf16`). Default
-      remains **fp32**. `fp16`/`bf16` use Keras mixed precision (float32
-      variables, reduced-precision compute).
+    * YAML `settings.train_dtype` (`float32` / `float64`, default
+      **float32**) sets the training float type. The ASE calculator takes
+      MACE-style `default_dtype` as a constructor argument only; empty
+      follows `train_dtype`.
 
 ### v2.1.0
 

--- a/docs/usage/cli/train.md
+++ b/docs/usage/cli/train.md
@@ -2,9 +2,12 @@
 
 Train a PiNN model given a parameter file.
 
-The parameter YAML may include `numeric.precision` (`fp32`, `fp16`, or
-`bf16`). It defaults to `fp32` when omitted. See
-[Models](../models.md#configuration).
+The parameter YAML may include `settings.train_dtype` (`float32` or
+`float64`; default `float32`). That key is training-only: it sets Keras
+`floatx` / dtype policy, so new network weights, Keras ops, and numpy/ANI
+float inputs use that width. Integer indices stay `int32`. TFRecords keep
+the dtype they were converted with. The ASE calculator's `default_dtype` is
+**not** in the YAML; see [Models](../models.md#settings-train_dtype).
 
 ## Usage
 

--- a/docs/usage/cli/train.md
+++ b/docs/usage/cli/train.md
@@ -2,8 +2,8 @@
 
 Train a PiNN model given a parameter file.
 
-The parameter YAML may include a top-level `precision` key (`fp32`, `fp16`,
-or `bf16`). It defaults to `fp32` when omitted. See
+The parameter YAML may include `numeric.precision` (`fp32`, `fp16`, or
+`bf16`). It defaults to `fp32` when omitted. See
 [Models](../models.md#configuration).
 
 ## Usage

--- a/docs/usage/cli/train.md
+++ b/docs/usage/cli/train.md
@@ -2,6 +2,10 @@
 
 Train a PiNN model given a parameter file.
 
+The parameter YAML may include a top-level `precision` key (`fp32`, `fp16`,
+or `bf16`). It defaults to `fp32` when omitted. See
+[Models](../models.md#configuration).
+
 ## Usage
 
 ```bash

--- a/docs/usage/cli/train.md
+++ b/docs/usage/cli/train.md
@@ -2,12 +2,9 @@
 
 Train a PiNN model given a parameter file.
 
-The parameter YAML may include `settings.train_dtype` (`float32` or
-`float64`; default `float32`). That key is training-only: it sets Keras
-`floatx` / dtype policy, so new network weights, Keras ops, and numpy/ANI
-float inputs use that width. Integer indices stay `int32`. TFRecords keep
-the dtype they were converted with. The ASE calculator's `default_dtype` is
-**not** in the YAML; see [Models](../models.md#settings-train_dtype).
+The parameter YAML may include `settings.dtype` (`float32` or
+`float64`; default `float32`). See [Models](../models.md#settings-dtype).
+The ASE calculator's `default_dtype` is **not** in the YAML.
 
 ## Usage
 

--- a/docs/usage/datasets.md
+++ b/docs/usage/datasets.md
@@ -28,6 +28,10 @@ We advise you to convert your dataset into the TFRecord format for training. The
 advantage of using this format is that it allows for the storage of preprocessed
 data and batched dataset.
 
+The `.yml` sidecar records each tensor's dtype at convert time. `settings.train_dtype`
+does not rewrite existing TFRecords; see
+[train_dtype](models.md#settings-train_dtype).
+
 ## Splitting the dataset
 
 It is a common practice to split the dataset into subsets for validation in

--- a/docs/usage/datasets.md
+++ b/docs/usage/datasets.md
@@ -28,9 +28,9 @@ We advise you to convert your dataset into the TFRecord format for training. The
 advantage of using this format is that it allows for the storage of preprocessed
 data and batched dataset.
 
-The `.yml` sidecar records each tensor's dtype at convert time. `settings.train_dtype`
+The `.yml` sidecar records each tensor's dtype at convert time. `settings.dtype`
 does not rewrite existing TFRecords; see
-[train_dtype](models.md#settings-train_dtype).
+[dtype](models.md#settings-dtype).
 
 ## Splitting the dataset
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -29,13 +29,15 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
-precision: fp32
+numeric:
+  precision: fp32
 ```
 
-`precision` is optional and defaults to `fp32`. Allowed values are `fp32`,
-`fp16`, and `bf16` (aliases `float32` / `float16` / `bfloat16`). Reduced
-precision uses Keras mixed precision: variables stay float32, compute runs
-in float16 or bfloat16. `fp16` applies a static loss scale of 128.
+`numeric` holds numerical runtime options. `precision` is optional and
+defaults to `fp32`. Allowed values are `fp32`, `fp16`, and `bf16` (aliases
+`float32` / `float16` / `bfloat16`). Reduced precision uses Keras mixed
+precision: variables stay float32, compute runs in float16 or bfloat16.
+`fp16` applies a static loss scale of 128.
 
 Among those, the `optimizer` section follows the format of a Keras optimizer.
 The `model` and `network` sections specify the name and parameters of initialize

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -29,7 +29,13 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
+precision: fp32
 ```
+
+`precision` is optional and defaults to `fp32`. Allowed values are `fp32`,
+`fp16`, and `bf16` (aliases `float32` / `float16` / `bfloat16`). Reduced
+precision uses Keras mixed precision: variables stay float32, compute runs
+in float16 or bfloat16. `fp16` applies a static loss scale of 128.
 
 Among those, the `optimizer` section follows the format of a Keras optimizer.
 The `model` and `network` sections specify the name and parameters of initialize

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -29,20 +29,88 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
-numeric:
-  precision: fp32
+settings:
+  train_dtype: float32
 ```
-
-`numeric` holds numerical runtime options. `precision` is optional and
-defaults to `fp32`. Allowed values are `fp32`, `fp16`, and `bf16` (aliases
-`float32` / `float16` / `bfloat16`). Reduced precision uses Keras mixed
-precision: variables stay float32, compute runs in float16 or bfloat16.
-`fp16` applies a static loss scale of 128.
 
 Among those, the `optimizer` section follows the format of a Keras optimizer.
 The `model` and `network` sections specify the name and parameters of initialize
 a PiNN model and network, respectively. A model can be initialized by a
 parameter file or a corresponding nested python dictionary.
+
+## Settings: `train_dtype`
+
+`settings` is training-time configuration. The only dtype key in the YAML is
+`train_dtype` (`float32` or `float64`; default `float32`). It is **not** the
+ASE calculator's `default_dtype` (that argument exists only on
+`PiNN_calc` / `get_calc`, see [Potential](potential.md#ase-calculator)).
+
+When a model is built, PiNN calls `tf.keras.backend.set_floatx` and
+`tf.keras.mixed_precision.set_global_policy` with this value. That is the
+Keras **default float type** for the process, so it decides the dtype of
+new floating tensors Keras creates, not integer index tensors.
+
+### What it does change
+
+| Piece | Effect of `train_dtype` |
+|-------|-------------------------|
+| Network weights | `Dense` (and other Keras) kernels and biases are created in this dtype. A float64 run stores float64 checkpoints; a float32 run stores float32. |
+| Keras compute | Matmuls, biases, activations inside those layers run in this dtype. |
+| Derived float tensors | Features that follow `coord.dtype` (atomic embeddings in PiNet/PiNet2, distances in the neighbor list, cell displacements) inherit the dtype of the coordinate tensor. |
+| Numpy datasets | `load_numpy` types every non-integer array as `keras.backend.floatx()`, so `coord`, `e_data`, `f_data`, … enter the pipeline in `train_dtype`. |
+| ANI loader | Coordinate and energy specs use `floatx()` as well. |
+| Loss and gradients | Energy/force/stress residuals and `tf.gradients` match the prediction/variable dtype. Adam-style optimizer slots follow the variables. |
+| `params.yml` | The chosen `train_dtype` is written next to the rest of the model spec so later loads (and an empty calculator `default_dtype`) can see it. |
+
+### What it does **not** change
+
+- **Integer tensors stay `int32`:** `elems`, `ind_1`, `ind_2`, and other sparse indices.
+- **Already-written TFRecords:** `pinn convert` serializes whatever dtypes the dataset had *at convert time* into the `.tfr` / `.yml` spec. Loading a float32 record in a float64 training job does **not** rewrite the file; TensorFlow will cast at the Keras layer boundary. For a true float64 pipeline, convert (or `load_numpy`) after `train_dtype` is set, or recast in the input function.
+- **EKF / gEKF inversion:** those optimizers still invert in `inv_dtype` (default float64) regardless of `train_dtype`.
+- **ASE `Atoms`:** positions and cells remain NumPy arrays (typically float64) until they are copied into a TensorFlow tensor.
+- **ASE MD state:** always float64; see inference below.
+
+### Inference and the ASE calculator
+
+**ASE MD is always float64.** Positions, cell, momenta, and the integrator
+stay NumPy float64. PiNN does not switch the MD state to float32.
+
+Training stores **every float parameter** in `train_dtype` (float32 or
+float64). Inference follows MACE: convert the **model** to the requested
+width, then run the whole network in that width.
+
+`default_dtype` is a constructor argument only (not YAML):
+
+```python
+get_calc(model_dir)                            # same dtype as training
+get_calc(model_dir, default_dtype='float32')   # like MACE model.float()
+```
+
+Empty / omitted → `settings.train_dtype`. If it **matches** training, the
+checkpoint is restored as usual. If it **differs**, PiNN builds the predict
+graph at `default_dtype` and loads the checkpoint with a one-time
+`tf.cast` into those variables (TensorFlow variables cannot change dtype
+in place, so this is the equivalent of PyTorch `model.to(dtype)` /
+`model.float()` / `model.double()`). After that:
+
+- Weights, embeddings, distances, `Dense` matmuls (`tf.linalg.matmul`)
+  and bias-adds (`tf.nn.bias_add`) are all `default_dtype`.
+- Predictor inputs `coord` and `cell` are created in the same dtype.
+  `elems` / `ind_1` stay `int32`.
+- There is no per-layer ping-pong cast.
+
+**Train float64, infer `default_dtype='float32'`:** checkpoint kernels
+are cast to float32 **once at load**; GEMMs run in float32. ASE still
+hands over float64 positions; they are copied into a float32 tensor at
+the calculator boundary, then everything in TF stays float32 until
+forces are written back. ASE continues the MD step in float64.
+
+**Train float32, infer `default_dtype='float64'`:** weights are cast up
+once; the network runs in float64. That is extra precision at inference,
+not extra precision that was in the checkpoint.
+
+To train in float32 end-to-end, set `settings.train_dtype: float32`. Do
+not expect `default_dtype` to replace that for training.
 
 ## Training
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -30,7 +30,7 @@ optimizer:
   config:
     learning_rate: 0.03
 settings:
-  train_dtype: float32
+  dtype: float32
 ```
 
 Among those, the `optimizer` section follows the format of a Keras optimizer.
@@ -38,79 +38,16 @@ The `model` and `network` sections specify the name and parameters of initialize
 a PiNN model and network, respectively. A model can be initialized by a
 parameter file or a corresponding nested python dictionary.
 
-## Settings: `train_dtype`
+## Settings: `dtype`
 
-`settings` is training-time configuration. The only dtype key in the YAML is
-`train_dtype` (`float32` or `float64`; default `float32`). It is **not** the
-ASE calculator's `default_dtype` (that argument exists only on
-`PiNN_calc` / `get_calc`, see [Potential](potential.md#ase-calculator)).
+`settings.dtype` is `float32` or `float64` (default `float32`). It sets
+Keras `floatx` / dtype policy so new float weights and ops use that width.
+Integer indices stay `int32`. Numpy/ANI loaders follow `floatx()`;
+existing TFRecords keep the dtype they were converted with. EKF / gEKF
+still invert in `inv_dtype` (default float64).
 
-When a model is built, PiNN calls `tf.keras.backend.set_floatx` and
-`tf.keras.mixed_precision.set_global_policy` with this value. That is the
-Keras **default float type** for the process, so it decides the dtype of
-new floating tensors Keras creates, not integer index tensors.
-
-### What it does change
-
-| Piece | Effect of `train_dtype` |
-|-------|-------------------------|
-| Network weights | `Dense` (and other Keras) kernels and biases are created in this dtype. A float64 run stores float64 checkpoints; a float32 run stores float32. |
-| Keras compute | Matmuls, biases, activations inside those layers run in this dtype. |
-| Derived float tensors | Features that follow `coord.dtype` (atomic embeddings in PiNet/PiNet2, distances in the neighbor list, cell displacements) inherit the dtype of the coordinate tensor. |
-| Numpy datasets | `load_numpy` types every non-integer array as `keras.backend.floatx()`, so `coord`, `e_data`, `f_data`, … enter the pipeline in `train_dtype`. |
-| ANI loader | Coordinate and energy specs use `floatx()` as well. |
-| Loss and gradients | Energy/force/stress residuals and `tf.gradients` match the prediction/variable dtype. Adam-style optimizer slots follow the variables. |
-| `params.yml` | The chosen `train_dtype` is written next to the rest of the model spec so later loads (and an empty calculator `default_dtype`) can see it. |
-
-### What it does **not** change
-
-- **Integer tensors stay `int32`:** `elems`, `ind_1`, `ind_2`, and other sparse indices.
-- **Already-written TFRecords:** `pinn convert` serializes whatever dtypes the dataset had *at convert time* into the `.tfr` / `.yml` spec. Loading a float32 record in a float64 training job does **not** rewrite the file; TensorFlow will cast at the Keras layer boundary. For a true float64 pipeline, convert (or `load_numpy`) after `train_dtype` is set, or recast in the input function.
-- **EKF / gEKF inversion:** those optimizers still invert in `inv_dtype` (default float64) regardless of `train_dtype`.
-- **ASE `Atoms`:** positions and cells remain NumPy arrays (typically float64) until they are copied into a TensorFlow tensor.
-- **ASE MD state:** always float64; see inference below.
-
-### Inference and the ASE calculator
-
-**ASE MD is always float64.** Positions, cell, momenta, and the integrator
-stay NumPy float64. PiNN does not switch the MD state to float32.
-
-Training stores **every float parameter** in `train_dtype` (float32 or
-float64). Inference follows MACE: convert the **model** to the requested
-width, then run the whole network in that width.
-
-`default_dtype` is a constructor argument only (not YAML):
-
-```python
-get_calc(model_dir)                            # same dtype as training
-get_calc(model_dir, default_dtype='float32')   # like MACE model.float()
-```
-
-Empty / omitted → `settings.train_dtype`. If it **matches** training, the
-checkpoint is restored as usual. If it **differs**, PiNN builds the predict
-graph at `default_dtype` and loads the checkpoint with a one-time
-`tf.cast` into those variables (TensorFlow variables cannot change dtype
-in place, so this is the equivalent of PyTorch `model.to(dtype)` /
-`model.float()` / `model.double()`). After that:
-
-- Weights, embeddings, distances, `Dense` matmuls (`tf.linalg.matmul`)
-  and bias-adds (`tf.nn.bias_add`) are all `default_dtype`.
-- Predictor inputs `coord` and `cell` are created in the same dtype.
-  `elems` / `ind_1` stay `int32`.
-- There is no per-layer ping-pong cast.
-
-**Train float64, infer `default_dtype='float32'`:** checkpoint kernels
-are cast to float32 **once at load**; GEMMs run in float32. ASE still
-hands over float64 positions; they are copied into a float32 tensor at
-the calculator boundary, then everything in TF stays float32 until
-forces are written back. ASE continues the MD step in float64.
-
-**Train float32, infer `default_dtype='float64'`:** weights are cast up
-once; the network runs in float64. That is extra precision at inference,
-not extra precision that was in the checkpoint.
-
-To train in float32 end-to-end, set `settings.train_dtype: float32`. Do
-not expect `default_dtype` to replace that for training.
+The ASE calculator's `default_dtype` is a constructor argument only (not
+YAML); see [Potential](potential.md#ase-calculator).
 
 ## Training
 

--- a/docs/usage/potential.md
+++ b/docs/usage/potential.md
@@ -56,11 +56,27 @@ descriptions.
 A calculator can be created from a model as simple as:
 
 ```Python
-from pinn.get_calc
+from pinn import get_calc
 calc = get_calc('/path/to/model/')
+calc = get_calc('/path/to/model/', default_dtype='float64')
 calc.calculate(atoms)
 calc.get_forces()
 ```
+
+**ASE MD is always float64** (positions, cell, momenta, the integrator).
+
+`default_dtype` is a constructor argument only, same idea as MACE
+`model.float()` / `model.double()`: if it differs from
+`settings.train_dtype`, checkpoint weights are `tf.cast` **once at
+load**, then the whole TF graph (weights, matmuls, bias-adds, neighbor
+list) runs in that dtype. ASE → TF is the only other conversion
+(float64 positions into the predictor tensor).
+
+Train float64 + `default_dtype='float32'` → a float32 **model**, not
+float32 inputs feeding a float64 net. Train float32 +
+`default_dtype='float64'` → weights cast up for this calculator only.
+
+Full path: [Models — inference](models.md#inference-and-the-ase-calculator).
 
 ### Units
 

--- a/docs/usage/potential.md
+++ b/docs/usage/potential.md
@@ -65,18 +65,11 @@ calc.get_forces()
 
 **ASE MD is always float64** (positions, cell, momenta, the integrator).
 
-`default_dtype` is a constructor argument only, same idea as MACE
-`model.float()` / `model.double()`: if it differs from
-`settings.train_dtype`, checkpoint weights are `tf.cast` **once at
-load**, then the whole TF graph (weights, matmuls, bias-adds, neighbor
-list) runs in that dtype. ASE → TF is the only other conversion
-(float64 positions into the predictor tensor).
-
-Train float64 + `default_dtype='float32'` → a float32 **model**, not
-float32 inputs feeding a float64 net. Train float32 +
-`default_dtype='float64'` → weights cast up for this calculator only.
-
-Full path: [Models — inference](models.md#inference-and-the-ase-calculator).
+`default_dtype` is a constructor argument only (not YAML), same idea as
+MACE `model.float()` / `model.double()`. ``None`` follows
+`settings.dtype`. If it differs, checkpoint weights are cast once at
+load and the TF graph runs in that dtype. See
+[Models](models.md#settings-dtype).
 
 ### Units
 

--- a/docs/usage/quick_start.md
+++ b/docs/usage/quick_start.md
@@ -82,6 +82,7 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
+precision: fp32   # optional; fp16 / bf16 for mixed precision
 ```
 
 ## Using the CLI

--- a/docs/usage/quick_start.md
+++ b/docs/usage/quick_start.md
@@ -82,7 +82,8 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
-precision: fp32   # optional; fp16 / bf16 for mixed precision
+numeric:
+  precision: fp32   # optional; fp16 / bf16 for mixed precision
 ```
 
 ## Using the CLI

--- a/docs/usage/quick_start.md
+++ b/docs/usage/quick_start.md
@@ -83,7 +83,7 @@ optimizer:
   config:
     learning_rate: 0.03
 settings:
-  train_dtype: float32   # float32 | float64; training only
+  dtype: float32   # float32 | float64; default float32
 ```
 
 ## Using the CLI

--- a/docs/usage/quick_start.md
+++ b/docs/usage/quick_start.md
@@ -82,8 +82,8 @@ optimizer:
   class_name: EKF
   config:
     learning_rate: 0.03
-numeric:
-  precision: fp32   # optional; fp16 / bf16 for mixed precision
+settings:
+  train_dtype: float32   # float32 | float64; training only
 ```
 
 ## Using the CLI

--- a/inputs/qm9-pinet2.yml
+++ b/inputs/qm9-pinet2.yml
@@ -24,7 +24,8 @@ network:
     out_nodes: [64]
     weighted: False
     rank: 3
-precision: fp32
+numeric:
+  precision: fp32
 optimizer:
   class_name: Adam
   config:

--- a/inputs/qm9-pinet2.yml
+++ b/inputs/qm9-pinet2.yml
@@ -25,7 +25,7 @@ network:
     weighted: False
     rank: 3
 settings:
-  train_dtype: float32
+  dtype: float32
 optimizer:
   class_name: Adam
   config:

--- a/inputs/qm9-pinet2.yml
+++ b/inputs/qm9-pinet2.yml
@@ -24,6 +24,7 @@ network:
     out_nodes: [64]
     weighted: False
     rank: 3
+precision: fp32
 optimizer:
   class_name: Adam
   config:

--- a/inputs/qm9-pinet2.yml
+++ b/inputs/qm9-pinet2.yml
@@ -24,8 +24,8 @@ network:
     out_nodes: [64]
     weighted: False
     rank: 3
-numeric:
-  precision: fp32
+settings:
+  train_dtype: float32
 optimizer:
   class_name: Adam
   config:

--- a/pinn/__init__.py
+++ b/pinn/__init__.py
@@ -10,7 +10,9 @@ def get_calc(model_spec, **kwargs):
     """Get a calculator from a trained model.
 
     The positional argument will be passed to `pinn.get_model`, keyword
-    arguments will be passed to the calculator.
+    arguments will be passed to the calculator. ``default_dtype`` is a
+    calculator argument (not YAML): empty string uses
+    ``settings.train_dtype``, else float32.
     """
     import tensorflow as tf
     from pinn import get_model

--- a/pinn/__init__.py
+++ b/pinn/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 from pinn.networks import get as get_network
 from pinn.models import get as get_model
@@ -11,8 +11,7 @@ def get_calc(model_spec, **kwargs):
 
     The positional argument will be passed to `pinn.get_model`, keyword
     arguments will be passed to the calculator. ``default_dtype`` is a
-    calculator argument (not YAML): empty string uses
-    ``settings.train_dtype``, else float32.
+    calculator argument (not YAML): ``None`` follows ``settings.dtype``.
     """
     import tensorflow as tf
     from pinn import get_model

--- a/pinn/calculator.py
+++ b/pinn/calculator.py
@@ -4,12 +4,15 @@
 import numpy as np
 import tensorflow as tf
 from ase.calculators.calculator import Calculator
+from pinn.models.base import (
+    set_infer_dtype, tf_dtype_from_name, train_dtype_from_params,
+)
 
 
 class PiNN_calc(Calculator):
     def __init__(self, model=None, atoms=None, to_eV=1.0,
                  properties=['energy', 'forces', 'stress'],
-                 checkpoint_path=None):
+                 checkpoint_path=None, default_dtype=''):
         """PiNN interface with ASE as a calculator
 
         Args:
@@ -19,6 +22,11 @@ class PiNN_calc(Calculator):
             properties: properties to calculate.
                 the properties to calculate is fixed for each calculator,
                 to avoid resetting the predictor during get_* calls.
+            default_dtype: MACE-style calculator arg (not a YAML key).
+                Empty follows ``settings.train_dtype``. If it differs from
+                the training dtype, checkpoint weights are cast once at
+                load (like ``model.float()`` / ``model.double()``) and the
+                whole network runs in that dtype. ASE MD stays float64.
         """
         Calculator.__init__(self)
         self.implemented_properties = properties
@@ -28,6 +36,16 @@ class PiNN_calc(Calculator):
         self.predictor = None
         self.to_eV = to_eV
         self.ckpt_path = checkpoint_path
+        self.default_dtype = default_dtype
+
+    def _dtype_name(self):
+        if self.default_dtype:
+            return self.default_dtype
+        params = getattr(self.model, 'params', None)
+        return train_dtype_from_params(params)
+
+    def _tf_dtype(self):
+        return tf_dtype_from_name(self._dtype_name())
 
     def _generator(self):
         while True:
@@ -45,11 +63,14 @@ class PiNN_calc(Calculator):
                     'elems': atoms.numbers}
             yield data
 
-    def get_predictor(self, dtype=tf.float32):
+    def get_predictor(self, dtype=None):
         if self.predictor is not None:
             return self.predictor
 
         self.size = len(self._atoms_to_calc)
+        if dtype is None:
+            dtype = self._tf_dtype()
+        set_infer_dtype(self._dtype_name())
 
         dtypes = {'coord': dtype, 'elems': tf.int32, 'ind_1': tf.int32}
         shapes = {'coord': [None, 3], 'elems': [None], 'ind_1': [None, 1]}

--- a/pinn/calculator.py
+++ b/pinn/calculator.py
@@ -5,14 +5,14 @@ import numpy as np
 import tensorflow as tf
 from ase.calculators.calculator import Calculator
 from pinn.models.base import (
-    set_infer_dtype, tf_dtype_from_name, train_dtype_from_params,
+    dtype_from_params, set_infer_dtype, tf_dtype_from_name,
 )
 
 
 class PiNN_calc(Calculator):
     def __init__(self, model=None, atoms=None, to_eV=1.0,
                  properties=['energy', 'forces', 'stress'],
-                 checkpoint_path=None, default_dtype=''):
+                 checkpoint_path=None, default_dtype=None):
         """PiNN interface with ASE as a calculator
 
         Args:
@@ -23,9 +23,9 @@ class PiNN_calc(Calculator):
                 the properties to calculate is fixed for each calculator,
                 to avoid resetting the predictor during get_* calls.
             default_dtype: MACE-style calculator arg (not a YAML key).
-                Empty follows ``settings.train_dtype``. If it differs from
-                the training dtype, checkpoint weights are cast once at
-                load (like ``model.float()`` / ``model.double()``) and the
+                ``None`` follows ``settings.dtype``. If it differs from
+                training, checkpoint weights are cast once at load
+                (like ``model.float()`` / ``model.double()``) and the
                 whole network runs in that dtype. ASE MD stays float64.
         """
         Calculator.__init__(self)
@@ -39,10 +39,10 @@ class PiNN_calc(Calculator):
         self.default_dtype = default_dtype
 
     def _dtype_name(self):
-        if self.default_dtype:
+        if self.default_dtype is not None:
             return self.default_dtype
         params = getattr(self.model, 'params', None)
-        return train_dtype_from_params(params)
+        return dtype_from_params(params)
 
     def _tf_dtype(self):
         return tf_dtype_from_name(self._dtype_name())

--- a/pinn/cli.py
+++ b/pinn/cli.py
@@ -93,7 +93,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
     from pinn import get_model, get_network
     from pinn.utils import init_params
     from pinn.io import load_tfrecord, sparse_batch
-    from pinn.models.base import apply_precision
+    from pinn.models.base import apply_precision, precision_from_params
     index_warning = 'Converting sparse IndexedSlices'
     warnings.filterwarnings('ignore', index_warning)
     tf.get_logger().setLevel('ERROR')
@@ -102,7 +102,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
         params = yaml.load(f, Loader=yaml.Loader)
     if model_dir is not None:
         params['model_dir'] = model_dir
-    apply_precision(params.get('precision', 'fp32'))
+    apply_precision(precision_from_params(params))
 
     if init:
         ds = load_tfrecord(train_ds)

--- a/pinn/cli.py
+++ b/pinn/cli.py
@@ -93,6 +93,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
     from pinn import get_model, get_network
     from pinn.utils import init_params
     from pinn.io import load_tfrecord, sparse_batch
+    from pinn.models.base import apply_precision
     index_warning = 'Converting sparse IndexedSlices'
     warnings.filterwarnings('ignore', index_warning)
     tf.get_logger().setLevel('ERROR')
@@ -101,6 +102,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
         params = yaml.load(f, Loader=yaml.Loader)
     if model_dir is not None:
         params['model_dir'] = model_dir
+    apply_precision(params.get('precision', 'fp32'))
 
     if init:
         ds = load_tfrecord(train_ds)

--- a/pinn/cli.py
+++ b/pinn/cli.py
@@ -93,7 +93,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
     from pinn import get_model, get_network
     from pinn.utils import init_params
     from pinn.io import load_tfrecord, sparse_batch
-    from pinn.models.base import apply_train_dtype, train_dtype_from_params
+    from pinn.models.base import apply_dtype, dtype_from_params
     index_warning = 'Converting sparse IndexedSlices'
     warnings.filterwarnings('ignore', index_warning)
     tf.get_logger().setLevel('ERROR')
@@ -102,7 +102,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
         params = yaml.load(f, Loader=yaml.Loader)
     if model_dir is not None:
         params['model_dir'] = model_dir
-    apply_train_dtype(train_dtype_from_params(params))
+    apply_dtype(dtype_from_params(params))
 
     if init:
         ds = load_tfrecord(train_ds)

--- a/pinn/cli.py
+++ b/pinn/cli.py
@@ -93,7 +93,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
     from pinn import get_model, get_network
     from pinn.utils import init_params
     from pinn.io import load_tfrecord, sparse_batch
-    from pinn.models.base import apply_precision, precision_from_params
+    from pinn.models.base import apply_train_dtype, train_dtype_from_params
     index_warning = 'Converting sparse IndexedSlices'
     warnings.filterwarnings('ignore', index_warning)
     tf.get_logger().setLevel('ERROR')
@@ -102,7 +102,7 @@ def train(params, model_dir, train_ds, eval_ds, batch, cache, preprocess,
         params = yaml.load(f, Loader=yaml.Loader)
     if model_dir is not None:
         params['model_dir'] = model_dir
-    apply_precision(precision_from_params(params))
+    apply_train_dtype(train_dtype_from_params(params))
 
     if init:
         ds = load_tfrecord(train_ds)

--- a/pinn/models/base.py
+++ b/pinn/models/base.py
@@ -14,7 +14,11 @@ def tf_dtype_from_name(name='float32'):
     """
     if name is None:
         name = 'float32'
-    dtype = tf.as_dtype(name)
+    try:
+        dtype = tf.as_dtype(name)
+    except TypeError as exc:
+        raise ValueError(
+            f'Unknown dtype {name!r}. Expected float32 or float64.') from exc
     if dtype not in (tf.float32, tf.float64):
         raise ValueError(
             f'Unknown dtype {name!r}. Expected float32 or float64.')

--- a/pinn/models/base.py
+++ b/pinn/models/base.py
@@ -3,17 +3,57 @@
 import tensorflow as tf
 from pinn.utils import pi_named
 
+# Public YAML names -> Keras mixed-precision policy.
+# fp16/bf16 keep float32 variables and compute in reduced precision.
+_PRECISION_POLICIES = {
+    'fp32': 'float32',
+    'float32': 'float32',
+    'fp16': 'mixed_float16',
+    'float16': 'mixed_float16',
+    'bf16': 'mixed_bfloat16',
+    'bfloat16': 'mixed_bfloat16',
+}
+_FP16_LOSS_SCALE = 128.0
+
+
+def apply_precision(precision='fp32'):
+    """Set the Keras mixed-precision policy used during training.
+
+    Args:
+        precision (str): ``fp32`` (default), ``fp16``, or ``bf16``.
+            Aliases ``float32`` / ``float16`` / ``bfloat16`` are accepted.
+
+    Returns:
+        str: the Keras policy name that was applied.
+    """
+    if precision is None:
+        precision = 'fp32'
+    key = str(precision).lower()
+    if key not in _PRECISION_POLICIES:
+        allowed = ', '.join(sorted(set(_PRECISION_POLICIES)))
+        raise ValueError(
+            f'Unknown precision {precision!r}. Expected one of: {allowed}.')
+    policy = _PRECISION_POLICIES[key]
+    tf.keras.mixed_precision.set_global_policy(policy)
+    return policy
+
+
 def export_model(model_fn):
     # default parameters for all models
     from pinn.optimizers import default_adam
-    default_params = {'optimizer': default_adam}
+    default_params = {'optimizer': default_adam, 'precision': 'fp32'}
     def pinn_model(params, **kwargs):
         model_dir = params['model_dir']
         params_tmp = default_params.copy()
         params_tmp.update(params)
         params = params_tmp
+        apply_precision(params.get('precision', 'fp32'))
+        def model_fn_with_precision(features, labels, mode, params):
+            apply_precision(params.get('precision', 'fp32'))
+            return model_fn(features, labels, mode, params)
         model = tf.estimator.Estimator(
-            model_fn=model_fn, params=params, model_dir=model_dir, **kwargs)
+            model_fn=model_fn_with_precision, params=params,
+            model_dir=model_dir, **kwargs)
         return model
     return pinn_model
 
@@ -89,7 +129,9 @@ def get_train_op(optimizer, metrics, tvars, separate_errors=False):
     optimizer = get(optimizer)
     optimizer.iterations = tf.compat.v1.train.get_or_create_global_step()
     nvars = np.sum([np.prod(var.shape) for var in tvars])
-    print(f'{nvars} trainable vaiables, training with {tvars[0].dtype.name} precision.')
+    compute_dtype = tf.keras.mixed_precision.global_policy().compute_dtype
+    print(f'{nvars} trainable vaiables, training with {tvars[0].dtype.name} '
+          f'variables / {compute_dtype} compute.')
 
     if not (isinstance(optimizer, EKF) or isinstance(optimizer, gEKF)):
         loss_list =  metrics.LOSS
@@ -98,7 +140,13 @@ def get_train_op(optimizer, metrics, tvars, separate_errors=False):
             loss = tf.stack(loss_list)[selection]
         else:
             loss = tf.reduce_sum(loss_list)
+        # mixed_float16 needs a loss scale so fp16 gradients do not underflow.
+        scale = _FP16_LOSS_SCALE if str(compute_dtype) == 'float16' else 1.0
+        if scale != 1.0:
+            loss = loss * scale
         grads = tf.gradients(loss, tvars)
+        if scale != 1.0:
+            grads = [g if g is None else g / scale for g in grads]
         return optimizer.apply_gradients(zip(grads, tvars))
     else:
         error_list =  metrics.ERROR

--- a/pinn/models/base.py
+++ b/pinn/models/base.py
@@ -4,42 +4,30 @@ import threading
 import tensorflow as tf
 from pinn.utils import pi_named
 
-# float32 / float64 names (fp32 / fp64 accepted). YAML uses train_dtype only.
-
-_DTYPE_NAMES = {
-    'float32': 'float32',
-    'fp32': 'float32',
-    'float64': 'float64',
-    'fp64': 'float64',
-}
 _infer_dtype = threading.local()
 
 
 def tf_dtype_from_name(name='float32'):
-    """Map ``float32`` / ``float64`` (or ``fp32`` / ``fp64``) to a ``tf.DType``.
+    """Map TF dtype name ``float32`` / ``float64`` to a ``tf.DType``.
 
-    Empty / ``None`` is float32.
+    ``None`` defaults to ``tf.float32``.
     """
-    if name is None or name == '':
-        return tf.float32
-    key = str(name).lower()
-    if key not in _DTYPE_NAMES:
-        allowed = ', '.join(sorted(set(_DTYPE_NAMES)))
+    if name is None:
+        name = 'float32'
+    dtype = tf.as_dtype(name)
+    if dtype not in (tf.float32, tf.float64):
         raise ValueError(
-            f'Unknown dtype {name!r}. Expected one of: {allowed}.')
-    return tf.as_dtype(_DTYPE_NAMES[key])
+            f'Unknown dtype {name!r}. Expected float32 or float64.')
+    return dtype
 
 
-def train_dtype_from_params(params):
-    """Read ``settings.train_dtype``; empty / missing means ``float32``."""
-    settings = params.get('settings') if isinstance(params, dict) else None
-    if not isinstance(settings, dict):
-        return 'float32'
-    name = settings.get('train_dtype') or ''
-    return 'float32' if name == '' else str(name)
+def dtype_from_params(params):
+    """Read ``settings.dtype``; missing means ``float32``."""
+    settings = (params or {}).get('settings') or {}
+    return settings.get('dtype', 'float32')
 
 
-def apply_train_dtype(name='float32'):
+def apply_dtype(name='float32'):
     """Set Keras floatx and dtype policy (all new float weights/ops)."""
     dtype = tf_dtype_from_name(name)
     tf.keras.backend.set_floatx(dtype.name)
@@ -50,10 +38,6 @@ def apply_train_dtype(name='float32'):
 def set_infer_dtype(name):
     """Calculator sets this before ``predict()`` (MACE ``default_dtype``)."""
     _infer_dtype.name = name
-
-
-def _canonical_dtype_name(name):
-    return tf_dtype_from_name(name).name
 
 
 class _CastSaver(tf.compat.v1.train.Saver):
@@ -87,7 +71,7 @@ class _CastSaver(tf.compat.v1.train.Saver):
 def export_model(model_fn):
     # default parameters for all models
     from pinn.optimizers import default_adam
-    default_settings = {'train_dtype': 'float32'}
+    default_settings = {'dtype': 'float32'}
     default_params = {'optimizer': default_adam, 'settings': default_settings}
     def pinn_model(params, **kwargs):
         model_dir = params['model_dir']
@@ -97,18 +81,18 @@ def export_model(model_fn):
         settings.update(params.get('settings') or {})
         params_tmp['settings'] = settings
         params = params_tmp
-        apply_train_dtype(train_dtype_from_params(params))
+        apply_dtype(dtype_from_params(params))
         def model_fn_with_dtype(features, labels, mode, params):
-            train_dt = train_dtype_from_params(params)
+            dt = dtype_from_params(params)
             if mode == tf.estimator.ModeKeys.PREDICT:
-                infer_dt = getattr(_infer_dtype, 'name', None) or train_dt
-                apply_train_dtype(infer_dt)
+                infer_dt = getattr(_infer_dtype, 'name', None) or dt
+                apply_dtype(infer_dt)
                 spec = model_fn(features, labels, mode, params)
-                if _canonical_dtype_name(infer_dt) != _canonical_dtype_name(train_dt):
+                if tf_dtype_from_name(infer_dt) != tf_dtype_from_name(dt):
                     spec = spec._replace(
                         scaffold=tf.compat.v1.train.Scaffold(saver=_CastSaver()))
                 return spec
-            apply_train_dtype(train_dt)
+            apply_dtype(dt)
             return model_fn(features, labels, mode, params)
         model = tf.estimator.Estimator(
             model_fn=model_fn_with_dtype, params=params,

--- a/pinn/models/base.py
+++ b/pinn/models/base.py
@@ -16,6 +16,14 @@ _PRECISION_POLICIES = {
 _FP16_LOSS_SCALE = 128.0
 
 
+def precision_from_params(params):
+    """Read ``numeric.precision`` from a PiNN parameter dict."""
+    numeric = params.get('numeric')
+    if not isinstance(numeric, dict):
+        return 'fp32'
+    return numeric.get('precision', 'fp32')
+
+
 def apply_precision(precision='fp32'):
     """Set the Keras mixed-precision policy used during training.
 
@@ -41,15 +49,19 @@ def apply_precision(precision='fp32'):
 def export_model(model_fn):
     # default parameters for all models
     from pinn.optimizers import default_adam
-    default_params = {'optimizer': default_adam, 'precision': 'fp32'}
+    default_numeric = {'precision': 'fp32'}
+    default_params = {'optimizer': default_adam, 'numeric': default_numeric}
     def pinn_model(params, **kwargs):
         model_dir = params['model_dir']
         params_tmp = default_params.copy()
         params_tmp.update(params)
+        numeric = dict(default_numeric)
+        numeric.update(params.get('numeric') or {})
+        params_tmp['numeric'] = numeric
         params = params_tmp
-        apply_precision(params.get('precision', 'fp32'))
+        apply_precision(precision_from_params(params))
         def model_fn_with_precision(features, labels, mode, params):
-            apply_precision(params.get('precision', 'fp32'))
+            apply_precision(precision_from_params(params))
             return model_fn(features, labels, mode, params)
         model = tf.estimator.Estimator(
             model_fn=model_fn_with_precision, params=params,

--- a/pinn/models/base.py
+++ b/pinn/models/base.py
@@ -1,70 +1,117 @@
 # -*- coding: utf-8 -*-
 """Basic functions for PiNN models"""
+import threading
 import tensorflow as tf
 from pinn.utils import pi_named
 
-# Public YAML names -> Keras mixed-precision policy.
-# fp16/bf16 keep float32 variables and compute in reduced precision.
-_PRECISION_POLICIES = {
-    'fp32': 'float32',
+# float32 / float64 names (fp32 / fp64 accepted). YAML uses train_dtype only.
+
+_DTYPE_NAMES = {
     'float32': 'float32',
-    'fp16': 'mixed_float16',
-    'float16': 'mixed_float16',
-    'bf16': 'mixed_bfloat16',
-    'bfloat16': 'mixed_bfloat16',
+    'fp32': 'float32',
+    'float64': 'float64',
+    'fp64': 'float64',
 }
-_FP16_LOSS_SCALE = 128.0
+_infer_dtype = threading.local()
 
 
-def precision_from_params(params):
-    """Read ``numeric.precision`` from a PiNN parameter dict."""
-    numeric = params.get('numeric')
-    if not isinstance(numeric, dict):
-        return 'fp32'
-    return numeric.get('precision', 'fp32')
+def tf_dtype_from_name(name='float32'):
+    """Map ``float32`` / ``float64`` (or ``fp32`` / ``fp64``) to a ``tf.DType``.
 
-
-def apply_precision(precision='fp32'):
-    """Set the Keras mixed-precision policy used during training.
-
-    Args:
-        precision (str): ``fp32`` (default), ``fp16``, or ``bf16``.
-            Aliases ``float32`` / ``float16`` / ``bfloat16`` are accepted.
-
-    Returns:
-        str: the Keras policy name that was applied.
+    Empty / ``None`` is float32.
     """
-    if precision is None:
-        precision = 'fp32'
-    key = str(precision).lower()
-    if key not in _PRECISION_POLICIES:
-        allowed = ', '.join(sorted(set(_PRECISION_POLICIES)))
+    if name is None or name == '':
+        return tf.float32
+    key = str(name).lower()
+    if key not in _DTYPE_NAMES:
+        allowed = ', '.join(sorted(set(_DTYPE_NAMES)))
         raise ValueError(
-            f'Unknown precision {precision!r}. Expected one of: {allowed}.')
-    policy = _PRECISION_POLICIES[key]
-    tf.keras.mixed_precision.set_global_policy(policy)
-    return policy
+            f'Unknown dtype {name!r}. Expected one of: {allowed}.')
+    return tf.as_dtype(_DTYPE_NAMES[key])
+
+
+def train_dtype_from_params(params):
+    """Read ``settings.train_dtype``; empty / missing means ``float32``."""
+    settings = params.get('settings') if isinstance(params, dict) else None
+    if not isinstance(settings, dict):
+        return 'float32'
+    name = settings.get('train_dtype') or ''
+    return 'float32' if name == '' else str(name)
+
+
+def apply_train_dtype(name='float32'):
+    """Set Keras floatx and dtype policy (all new float weights/ops)."""
+    dtype = tf_dtype_from_name(name)
+    tf.keras.backend.set_floatx(dtype.name)
+    tf.keras.mixed_precision.set_global_policy(dtype.name)
+    return dtype.name
+
+
+def set_infer_dtype(name):
+    """Calculator sets this before ``predict()`` (MACE ``default_dtype``)."""
+    _infer_dtype.name = name
+
+
+def _canonical_dtype_name(name):
+    return tf_dtype_from_name(name).name
+
+
+class _CastSaver(tf.compat.v1.train.Saver):
+    """Restore a checkpoint into variables of a (possibly different) dtype.
+
+    TensorFlow variables cannot change dtype in place, so this is the
+    equivalent of PyTorch ``model.float()`` / ``model.double()``: build
+    the graph at the target dtype, then ``tf.cast`` each weight once at
+    load. After that every op runs in the target dtype.
+    """
+
+    def __init__(self):
+        super().__init__(var_list=[], allow_empty=True)
+
+    def restore(self, sess, save_path):
+        import numpy as np
+        reader = tf.compat.v1.train.load_checkpoint(save_path)
+        keys = reader.get_variable_to_shape_map()
+        assigns = []
+        for var in tf.compat.v1.global_variables():
+            key = var.op.name
+            if key not in keys:
+                continue
+            raw = np.asarray(reader.get_tensor(key))
+            dst = var.dtype.base_dtype.as_numpy_dtype
+            assigns.append(var.assign(raw.astype(dst, copy=False)))
+        if assigns:
+            sess.run(assigns)
 
 
 def export_model(model_fn):
     # default parameters for all models
     from pinn.optimizers import default_adam
-    default_numeric = {'precision': 'fp32'}
-    default_params = {'optimizer': default_adam, 'numeric': default_numeric}
+    default_settings = {'train_dtype': 'float32'}
+    default_params = {'optimizer': default_adam, 'settings': default_settings}
     def pinn_model(params, **kwargs):
         model_dir = params['model_dir']
         params_tmp = default_params.copy()
         params_tmp.update(params)
-        numeric = dict(default_numeric)
-        numeric.update(params.get('numeric') or {})
-        params_tmp['numeric'] = numeric
+        settings = dict(default_settings)
+        settings.update(params.get('settings') or {})
+        params_tmp['settings'] = settings
         params = params_tmp
-        apply_precision(precision_from_params(params))
-        def model_fn_with_precision(features, labels, mode, params):
-            apply_precision(precision_from_params(params))
+        apply_train_dtype(train_dtype_from_params(params))
+        def model_fn_with_dtype(features, labels, mode, params):
+            train_dt = train_dtype_from_params(params)
+            if mode == tf.estimator.ModeKeys.PREDICT:
+                infer_dt = getattr(_infer_dtype, 'name', None) or train_dt
+                apply_train_dtype(infer_dt)
+                spec = model_fn(features, labels, mode, params)
+                if _canonical_dtype_name(infer_dt) != _canonical_dtype_name(train_dt):
+                    spec = spec._replace(
+                        scaffold=tf.compat.v1.train.Scaffold(saver=_CastSaver()))
+                return spec
+            apply_train_dtype(train_dt)
             return model_fn(features, labels, mode, params)
         model = tf.estimator.Estimator(
-            model_fn=model_fn_with_precision, params=params,
+            model_fn=model_fn_with_dtype, params=params,
             model_dir=model_dir, **kwargs)
         return model
     return pinn_model
@@ -141,9 +188,7 @@ def get_train_op(optimizer, metrics, tvars, separate_errors=False):
     optimizer = get(optimizer)
     optimizer.iterations = tf.compat.v1.train.get_or_create_global_step()
     nvars = np.sum([np.prod(var.shape) for var in tvars])
-    compute_dtype = tf.keras.mixed_precision.global_policy().compute_dtype
-    print(f'{nvars} trainable vaiables, training with {tvars[0].dtype.name} '
-          f'variables / {compute_dtype} compute.')
+    print(f'{nvars} trainable vaiables, training with {tvars[0].dtype.name} precision.')
 
     if not (isinstance(optimizer, EKF) or isinstance(optimizer, gEKF)):
         loss_list =  metrics.LOSS
@@ -152,13 +197,7 @@ def get_train_op(optimizer, metrics, tvars, separate_errors=False):
             loss = tf.stack(loss_list)[selection]
         else:
             loss = tf.reduce_sum(loss_list)
-        # mixed_float16 needs a loss scale so fp16 gradients do not underflow.
-        scale = _FP16_LOSS_SCALE if str(compute_dtype) == 'float16' else 1.0
-        if scale != 1.0:
-            loss = loss * scale
         grads = tf.gradients(loss, tvars)
-        if scale != 1.0:
-            grads = [g if g is None else g / scale for g in grads]
         return optimizer.apply_gradients(zip(grads, tvars))
     else:
         error_list =  metrics.ERROR

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""settings.train_dtype (YAML) and calculator default_dtype (constructor)."""
+"""settings.dtype (YAML) and calculator default_dtype (constructor)."""
 import os
 import tempfile
 
@@ -10,30 +10,31 @@ from tensorflow.python.lib.io.file_io import FileIO
 
 from pinn.calculator import PiNN_calc
 from pinn.models.base import (
-    apply_train_dtype, tf_dtype_from_name, train_dtype_from_params,
+    apply_dtype, dtype_from_params, tf_dtype_from_name,
 )
 
 
 def test_tf_dtype_from_name():
     assert tf_dtype_from_name('float32') == tf.float32
-    assert tf_dtype_from_name('fp64') == tf.float64
-    assert tf_dtype_from_name('') == tf.float32
+    assert tf_dtype_from_name('float64') == tf.float64
+    assert tf_dtype_from_name(None) == tf.float32
     with pytest.raises(ValueError, match='Unknown dtype'):
         tf_dtype_from_name('float16')
+    with pytest.raises(ValueError, match='Unknown dtype'):
+        tf_dtype_from_name('fp64')
 
 
-def test_train_dtype_from_params():
-    assert train_dtype_from_params({}) == 'float32'
-    assert train_dtype_from_params({'settings': None}) == 'float32'
-    assert train_dtype_from_params(
-        {'settings': {'train_dtype': 'float64'}}) == 'float64'
+def test_dtype_from_params():
+    assert dtype_from_params({}) == 'float32'
+    assert dtype_from_params({'settings': None}) == 'float32'
+    assert dtype_from_params({'settings': {'dtype': 'float64'}}) == 'float64'
 
 
 def test_calc_default_dtype_is_constructor_only():
     class _Model:
-        params = {'settings': {'train_dtype': 'float64'}}
+        params = {'settings': {'dtype': 'float64'}}
 
-    calc = PiNN_calc(model=_Model(), default_dtype='')
+    calc = PiNN_calc(model=_Model())
     assert calc._dtype_name() == 'float64'
     assert calc._tf_dtype() == tf.float64
     calc_override = PiNN_calc(model=_Model(), default_dtype='float32')
@@ -43,34 +44,29 @@ def test_calc_default_dtype_is_constructor_only():
 
 
 @pytest.mark.forked
-def test_unknown_train_dtype_raises():
+def test_unknown_dtype_raises():
     with pytest.raises(ValueError, match='Unknown dtype'):
-        apply_train_dtype('fp16')
+        apply_dtype('fp16')
 
 
 @pytest.mark.forked
 def test_float32_is_the_default():
-    apply_train_dtype('float32')
+    apply_dtype('float32')
     assert tf.keras.backend.floatx() == 'float32'
-    apply_train_dtype(None)
+    apply_dtype(None)
     assert tf.keras.backend.floatx() == 'float32'
 
 
-@pytest.mark.parametrize('name,keras', [
-    ('float32', 'float32'),
-    ('fp32', 'float32'),
-    ('float64', 'float64'),
-    ('fp64', 'float64'),
-])
+@pytest.mark.parametrize('name', ['float32', 'float64'])
 @pytest.mark.forked
-def test_apply_train_dtype(name, keras):
-    apply_train_dtype(name)
-    assert tf.keras.backend.floatx() == keras
-    apply_train_dtype('float32')
+def test_apply_dtype(name):
+    apply_dtype(name)
+    assert tf.keras.backend.floatx() == name
+    apply_dtype('float32')
 
 
 @pytest.mark.forked
-def test_default_params_record_train_dtype():
+def test_default_params_record_dtype():
     import pinn
     testpath = tempfile.mkdtemp()
     params = {
@@ -92,9 +88,9 @@ def test_default_params_record_train_dtype():
     pinn.get_model(params)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved.get('settings', {}).get('train_dtype', 'float32') == 'float32'
+    assert saved.get('settings', {}).get('dtype', 'float32') == 'float32'
     assert 'default_dtype' not in saved.get('settings', {})
-    apply_train_dtype('float32')
+    apply_dtype('float32')
 
 
 @pytest.mark.forked
@@ -112,7 +108,7 @@ def test_float64_trains():
     }
     params = {
         'model_dir': testpath,
-        'settings': {'train_dtype': 'float64'},
+        'settings': {'dtype': 'float64'},
         'network': {
             'name': 'PiNet',
             'params': {
@@ -140,5 +136,5 @@ def test_float64_trains():
     tf.estimator.train_and_evaluate(model, train_spec, eval_spec)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved['settings']['train_dtype'] == 'float64'
-    apply_train_dtype('float32')
+    assert saved['settings']['dtype'] == 'float64'
+    apply_dtype('float32')

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -8,7 +8,13 @@ import tensorflow as tf
 import yaml
 from tensorflow.python.lib.io.file_io import FileIO
 
-from pinn.models.base import apply_precision
+from pinn.models.base import apply_precision, precision_from_params
+
+
+def test_precision_from_params_reads_numeric_block():
+    assert precision_from_params({}) == 'fp32'
+    assert precision_from_params({'numeric': None}) == 'fp32'
+    assert precision_from_params({'numeric': {'precision': 'bf16'}}) == 'bf16'
 
 
 @pytest.mark.forked
@@ -61,7 +67,7 @@ def test_default_params_record_fp32():
     pinn.get_model(params)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved.get('precision', 'fp32') == 'fp32'
+    assert saved.get('numeric', {}).get('precision', 'fp32') == 'fp32'
     apply_precision('fp32')
 
 
@@ -80,7 +86,7 @@ def test_fp16_precision_trains():
     }
     params = {
         'model_dir': testpath,
-        'precision': 'fp16',
+        'numeric': {'precision': 'fp16'},
         'network': {
             'name': 'PiNet',
             'params': {
@@ -108,5 +114,5 @@ def test_fp16_precision_trains():
     tf.estimator.train_and_evaluate(model, train_spec, eval_spec)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved['precision'] == 'fp16'
+    assert saved['numeric']['precision'] == 'fp16'
     apply_precision('fp32')

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Training-precision YAML parameter"""
+import os
+import tempfile
+
+import pytest
+import tensorflow as tf
+import yaml
+from tensorflow.python.lib.io.file_io import FileIO
+
+from pinn.models.base import apply_precision
+
+
+@pytest.mark.forked
+def test_unknown_precision_raises():
+    with pytest.raises(ValueError, match='Unknown precision'):
+        apply_precision('fp8')
+
+
+@pytest.mark.forked
+def test_fp32_is_the_default_policy():
+    apply_precision('fp32')
+    assert tf.keras.mixed_precision.global_policy().name == 'float32'
+    apply_precision(None)
+    assert tf.keras.mixed_precision.global_policy().name == 'float32'
+
+
+@pytest.mark.parametrize('name,policy', [
+    ('fp32', 'float32'),
+    ('float32', 'float32'),
+    ('fp16', 'mixed_float16'),
+    ('bf16', 'mixed_bfloat16'),
+])
+@pytest.mark.forked
+def test_apply_precision_sets_policy(name, policy):
+    apply_precision(name)
+    assert tf.keras.mixed_precision.global_policy().name == policy
+    apply_precision('fp32')
+
+
+@pytest.mark.forked
+def test_default_params_record_fp32():
+    import pinn
+    testpath = tempfile.mkdtemp()
+    params = {
+        'model_dir': testpath,
+        'network': {
+            'name': 'PiNet',
+            'params': {
+                'ii_nodes': [4, 4],
+                'pi_nodes': [4, 4],
+                'pp_nodes': [4, 4],
+                'out_nodes': [4],
+                'depth': 2,
+                'rc': 4.0,
+                'n_basis': 4,
+                'atom_types': [1]}},
+        'model': {
+            'name': 'potential_model',
+            'params': {'use_force': False}}}
+    pinn.get_model(params)
+    with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
+        saved = yaml.load(f, Loader=yaml.Loader)
+    assert saved.get('precision', 'fp32') == 'fp32'
+    apply_precision('fp32')
+
+
+@pytest.mark.forked
+def test_fp16_precision_trains():
+    import numpy as np
+    import pinn
+    from pinn.io import load_numpy, sparse_batch
+
+    testpath = tempfile.mkdtemp()
+    n = 8
+    data = {
+        'coord': np.random.randn(n, 3, 3).astype(np.float32),
+        'elems': np.ones((n, 3), dtype=np.int32),
+        'e_data': np.random.randn(n).astype(np.float32),
+    }
+    params = {
+        'model_dir': testpath,
+        'precision': 'fp16',
+        'network': {
+            'name': 'PiNet',
+            'params': {
+                'ii_nodes': [4, 4],
+                'pi_nodes': [4, 4],
+                'pp_nodes': [4, 4],
+                'out_nodes': [4],
+                'depth': 2,
+                'rc': 4.0,
+                'n_basis': 4,
+                'atom_types': [1]}},
+        'model': {
+            'name': 'potential_model',
+            'params': {'use_force': False}}}
+
+    def train():
+        return load_numpy(data).repeat().shuffle(n).apply(sparse_batch(4))
+
+    def test():
+        return load_numpy(data).apply(sparse_batch(4))
+
+    model = pinn.get_model(params)
+    train_spec = tf.estimator.TrainSpec(input_fn=train, max_steps=2)
+    eval_spec = tf.estimator.EvalSpec(input_fn=test, steps=1)
+    tf.estimator.train_and_evaluate(model, train_spec, eval_spec)
+    with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
+        saved = yaml.load(f, Loader=yaml.Loader)
+    assert saved['precision'] == 'fp16'
+    apply_precision('fp32')

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Training-precision YAML parameter"""
+"""settings.train_dtype (YAML) and calculator default_dtype (constructor)."""
 import os
 import tempfile
 
@@ -8,44 +8,69 @@ import tensorflow as tf
 import yaml
 from tensorflow.python.lib.io.file_io import FileIO
 
-from pinn.models.base import apply_precision, precision_from_params
+from pinn.calculator import PiNN_calc
+from pinn.models.base import (
+    apply_train_dtype, tf_dtype_from_name, train_dtype_from_params,
+)
 
 
-def test_precision_from_params_reads_numeric_block():
-    assert precision_from_params({}) == 'fp32'
-    assert precision_from_params({'numeric': None}) == 'fp32'
-    assert precision_from_params({'numeric': {'precision': 'bf16'}}) == 'bf16'
+def test_tf_dtype_from_name():
+    assert tf_dtype_from_name('float32') == tf.float32
+    assert tf_dtype_from_name('fp64') == tf.float64
+    assert tf_dtype_from_name('') == tf.float32
+    with pytest.raises(ValueError, match='Unknown dtype'):
+        tf_dtype_from_name('float16')
+
+
+def test_train_dtype_from_params():
+    assert train_dtype_from_params({}) == 'float32'
+    assert train_dtype_from_params({'settings': None}) == 'float32'
+    assert train_dtype_from_params(
+        {'settings': {'train_dtype': 'float64'}}) == 'float64'
+
+
+def test_calc_default_dtype_is_constructor_only():
+    class _Model:
+        params = {'settings': {'train_dtype': 'float64'}}
+
+    calc = PiNN_calc(model=_Model(), default_dtype='')
+    assert calc._dtype_name() == 'float64'
+    assert calc._tf_dtype() == tf.float64
+    calc_override = PiNN_calc(model=_Model(), default_dtype='float32')
+    assert calc_override._tf_dtype() == tf.float32
+    calc_plain = PiNN_calc(model=type('M', (), {})())
+    assert calc_plain._tf_dtype() == tf.float32
 
 
 @pytest.mark.forked
-def test_unknown_precision_raises():
-    with pytest.raises(ValueError, match='Unknown precision'):
-        apply_precision('fp8')
+def test_unknown_train_dtype_raises():
+    with pytest.raises(ValueError, match='Unknown dtype'):
+        apply_train_dtype('fp16')
 
 
 @pytest.mark.forked
-def test_fp32_is_the_default_policy():
-    apply_precision('fp32')
-    assert tf.keras.mixed_precision.global_policy().name == 'float32'
-    apply_precision(None)
-    assert tf.keras.mixed_precision.global_policy().name == 'float32'
+def test_float32_is_the_default():
+    apply_train_dtype('float32')
+    assert tf.keras.backend.floatx() == 'float32'
+    apply_train_dtype(None)
+    assert tf.keras.backend.floatx() == 'float32'
 
 
-@pytest.mark.parametrize('name,policy', [
-    ('fp32', 'float32'),
+@pytest.mark.parametrize('name,keras', [
     ('float32', 'float32'),
-    ('fp16', 'mixed_float16'),
-    ('bf16', 'mixed_bfloat16'),
+    ('fp32', 'float32'),
+    ('float64', 'float64'),
+    ('fp64', 'float64'),
 ])
 @pytest.mark.forked
-def test_apply_precision_sets_policy(name, policy):
-    apply_precision(name)
-    assert tf.keras.mixed_precision.global_policy().name == policy
-    apply_precision('fp32')
+def test_apply_train_dtype(name, keras):
+    apply_train_dtype(name)
+    assert tf.keras.backend.floatx() == keras
+    apply_train_dtype('float32')
 
 
 @pytest.mark.forked
-def test_default_params_record_fp32():
+def test_default_params_record_train_dtype():
     import pinn
     testpath = tempfile.mkdtemp()
     params = {
@@ -67,12 +92,13 @@ def test_default_params_record_fp32():
     pinn.get_model(params)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved.get('numeric', {}).get('precision', 'fp32') == 'fp32'
-    apply_precision('fp32')
+    assert saved.get('settings', {}).get('train_dtype', 'float32') == 'float32'
+    assert 'default_dtype' not in saved.get('settings', {})
+    apply_train_dtype('float32')
 
 
 @pytest.mark.forked
-def test_fp16_precision_trains():
+def test_float64_trains():
     import numpy as np
     import pinn
     from pinn.io import load_numpy, sparse_batch
@@ -80,13 +106,13 @@ def test_fp16_precision_trains():
     testpath = tempfile.mkdtemp()
     n = 8
     data = {
-        'coord': np.random.randn(n, 3, 3).astype(np.float32),
+        'coord': np.random.randn(n, 3, 3).astype(np.float64),
         'elems': np.ones((n, 3), dtype=np.int32),
-        'e_data': np.random.randn(n).astype(np.float32),
+        'e_data': np.random.randn(n).astype(np.float64),
     }
     params = {
         'model_dir': testpath,
-        'numeric': {'precision': 'fp16'},
+        'settings': {'train_dtype': 'float64'},
         'network': {
             'name': 'PiNet',
             'params': {
@@ -114,5 +140,5 @@ def test_fp16_precision_trains():
     tf.estimator.train_and_evaluate(model, train_spec, eval_spec)
     with FileIO(os.path.join(testpath, 'params.yml'), 'r') as f:
         saved = yaml.load(f, Loader=yaml.Loader)
-    assert saved['numeric']['precision'] == 'fp16'
-    apply_precision('fp32')
+    assert saved['settings']['train_dtype'] == 'float64'
+    apply_train_dtype('float32')


### PR DESCRIPTION
## Summary
- YAML `settings.dtype` is `float32` or `float64` (default `float32`). Float weights and Keras ops use that dtype.
- ASE calculator `default_dtype` is a constructor argument only (not YAML), same idea as MACE. `None` follows `settings.dtype`.
- If inference dtype differs from training, the predict graph is built at `default_dtype` and the checkpoint is cast once at load (`tf.cast` into the new variables — TF equivalent of `model.float()` / `model.double()`). After that the whole network runs in that dtype.
- ASE MD stays float64; the calculator boundary copies ASE arrays into TF tensors of `default_dtype`.
- Ships as **v2.1.1**.

```yaml
settings:
  dtype: float32
```

```python
get_calc(model_dir)                            # same dtype as training
get_calc(model_dir, default_dtype='float32')   # like MACE model.float()
```

## Test plan
- [ ] `tests/test_precision.py`: name parsing, YAML `dtype`, calculator override, float32 default, float64 short train
- [ ] existing potential tests still pass